### PR TITLE
Explicitly require sprockets-rails on gem load

### DIFF
--- a/example/config/application.rb
+++ b/example/config/application.rb
@@ -2,7 +2,6 @@ require File.expand_path('../boot', __FILE__)
 
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
-require 'sprockets/railtie'
 
 Bundler.require(*Rails.groups)
 

--- a/lib/premailer/rails/railtie.rb
+++ b/lib/premailer/rails/railtie.rb
@@ -1,3 +1,5 @@
+require 'sprockets/railtie'
+
 class Premailer
   module Rails
     class Railtie < ::Rails::Railtie

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -2,7 +2,6 @@ require_relative 'boot'
 
 require "action_mailer/railtie"
 require "action_view/railtie"
-require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)


### PR DESCRIPTION
After upgrading to premailer-rails >= 1.10.0, I encounter the following error unless 'sprockets/railtie' is explicitly required:
```
NoMethodError: undefined method `assets_manifest' for #<Api::Application:0x0000000003c40fb0>
  from premailer/rails/css_loaders/asset_pipeline_loader.rb:27:in `asset_pipeline_present?'
  from premailer/rails/css_loaders/asset_pipeline_loader.rb:8:in `load'
  from premailer/rails/css_helper.rb:47:in `block in load_css'
  from premailer/rails/css_helper.rb:46:in `each'
  from premailer/rails/css_helper.rb:46:in `load_css'
  from premailer/rails/css_helper.rb:38:in `load_css_with_cache'
  from premailer/rails/css_helper.rb:18:in `css_for_url'
  from premailer/rails/css_helper.rb:13:in `block in css_for_doc'
  from premailer/rails/css_helper.rb:13:in `map'
  from premailer/rails/css_helper.rb:13:in `css_for_doc'
  from premailer/rails/customized_premailer.rb:14:in `initialize'
  from premailer/rails/hook.rb:97:in `new'
  from premailer/rails/hook.rb:97:in `premailer'
  from premailer/rails/hook.rb:86:in `generate_text_part'
  from premailer/rails/hook.rb:62:in `generate_alternative_part'
  from premailer/rails/hook.rb:50:in `generate_html_part_replacement'
  from premailer/rails/hook.rb:24:in `perform'
  from premailer/rails/hook.rb:8:in `perform'
```
This change would ensure it is available on gem load.